### PR TITLE
chore: Update `setup-lazarus` to version 2.2.6

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,11 +15,11 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest,windows-latest]
-        lazarus-versions: [dist, 2.0.6, 1.6.4, 1.6.2]
+        lazarus-versions: [dist, 2.0.10, 2.0.8, 2.0.6, 1.6.4, 1.6.2]
     steps:
     - uses: actions/checkout@v2
     - name: Install Lazarus
-      uses: gcarreno/setup-lazarus@v2.1
+      uses: gcarreno/setup-lazarus@v2.2.6
       with:
         lazarus-version: ${{ matrix.lazarus-versions }}
     - name: Build the Main Application


### PR DESCRIPTION
Looks like this was WAAAAAAY behind and it's now not compatible with Windows instances.